### PR TITLE
Add support for using the full Roadshow version, if found

### DIFF
--- a/Assets/Functions/ProcessInstallFiles/Write-AmigaFilestoInterimDrive.ps1
+++ b/Assets/Functions/ProcessInstallFiles/Write-AmigaFilestoInterimDrive.ps1
@@ -67,6 +67,28 @@ function Write-AmigaFilestoInterimDrive {
     
     Write-TaskCompleteMessage 
 
+    # Check for Custom Roadshow
+    $RoadshowPackages = $ListofPackagestoInstall | Where-Object {$_.PackageName -eq "Roadshow"}
+    $CustomRoadshowPath = "$($Script:Settings.LocationofAmigaFiles)\LocalAmigaPackages\Roadshow-1.15.lha"
+    
+    if ($RoadshowPackages -and (Test-Path $CustomRoadshowPath)) {
+        Write-InformationMessage -Message "Custom Roadshow archive found. Using 'Roadshow-1.15.lha' instead of bundled Demo."
+        
+        foreach ($Package in $RoadshowPackages) {
+             $Package.Source = "Local - LHA File"
+             $Package.SourceLocation = "LocalAmigaPackages\Roadshow-1.15.lha"
+             # Reset other potential flags that might interfere
+             $Package.FileDownloadName = $null 
+             $Package.GithubRelease = $null
+
+             # Update FilestoInstall to point to the non-demo folder structure
+             # Replaces "Roadshow-Demo-*" or "Roadshow-Demo-1.15" with "Roadshow-1.15"
+             if ($Package.FilestoInstall -match "Roadshow-Demo") {
+                 $Package.FilestoInstall = $Package.FilestoInstall -replace "Roadshow-Demo-[^\\]*", "Roadshow-1.15"
+             }
+        }
+    } 
+
     if ($DownloadFilesFromInternet){
     
         $Script:Settings.CurrentTaskName = "Getting Packages from Internet"

--- a/Assets/Functions/Startup/Confirm-Prerequisites/Confirm-NoExtraAmigaFiles.ps1
+++ b/Assets/Functions/Startup/Confirm-Prerequisites/Confirm-NoExtraAmigaFiles.ps1
@@ -7,6 +7,7 @@ $ListofFiles = @"
     \EMU68Boot\config.txt
     \EMU68Boot\ps32lite-stealth-firmware.gz
     \LocalAmigaPackages\Roadshow-Demo-1.15.lha
+    \LocalAmigaPackages\Roadshow-1.15.lha
     \System\C\AreWeOnline
     \System\C\AreWePAL
     \System\C\CE


### PR DESCRIPTION
If Roadshow-1.15.lha is found in the Assets, use that instead of the Demo version.

This allows people to use the fully registered version of Roadshow, if they have it, and not having to replace the installed Demo version _after_ the image is created.

If you feel like this should be placed in another directory, we can do that. I picked the easiest option for now (same location as the Demo).