### PR TITLE
fix: fix 64bits detection on windows 11

### DIFF
--- a/Assets/Functions/Startup/Confirm-Prerequisites/Test-Architecture.ps1
+++ b/Assets/Functions/Startup/Confirm-Prerequisites/Test-Architecture.ps1
@@ -3,7 +3,7 @@ function Test-Architecture {
         
     )
 
-    if (($Script:Settings.Architecture -eq '64-bit') -or ($Script:Settings.Architecture -eq '64 bit')){
+    if (($Script:Settings.Architecture -eq '64-bit') -or ($Script:Settings.Architecture -eq '64 bit') -or ($Script:Settings.Architecture -eq '64 Bits')){
         $Valuetoreturn = "64bit"
     }
     elseif ($Script:Settings.Architecture -match 'ARM 64-bit'){


### PR DESCRIPTION
# What

This fix an issue about 64 bit detection

# Why

Under my Windows 11 Pro (update 25H2), the program says that it requires a 64Bit OS. However, i'm running a 64Bit os.

# How

- Echoing the `$Script:Settings.Architecture` under my system outputs `64 Bits`
- Adding this variation to the 64Bit test to allow this variant to be valid